### PR TITLE
chore: добавлено правило ESLint для одинарных кавычек

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,7 @@ export default defineConfig([
       ...pluginReact.configs.flat.recommended.rules,
       'react/react-in-jsx-scope': 'off',
       'react/jsx-no-target-blank': 'off',
+      quotes: ['error', 'single'],
     },
   },
   {


### PR DESCRIPTION
- В `eslint.config.js` добавлено правило `quotes: ['error', 'single']`
- Это правило гарантирует, что все строки в проекте будут использовать только одинарные кавычки
- ESLint теперь будет ругаться, если найдёт двойные кавычки в коде